### PR TITLE
Feat: Secured CRUD for category and improve Swagger responses

### DIFF
--- a/src/main/java/com/hoangtrang/taskoserver/config/security/CustomUserDetails.java
+++ b/src/main/java/com/hoangtrang/taskoserver/config/security/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package com.hoangtrang.taskoserver.config.security;
 
 import com.hoangtrang.taskoserver.model.User;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,10 +9,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
-@RequiredArgsConstructor
-public class CustomUserDetails implements UserDetails {
 
-    private final User user;
+public record CustomUserDetails(User user) implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/hoangtrang/taskoserver/controller/AuthController.java
+++ b/src/main/java/com/hoangtrang/taskoserver/controller/AuthController.java
@@ -5,8 +5,6 @@ import com.hoangtrang.taskoserver.dto.response.*;
 import com.hoangtrang.taskoserver.service.AuthService;
 import com.nimbusds.jose.JOSEException;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
@@ -31,12 +29,6 @@ public class AuthController {
 
     AuthService authService;
 
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "400", ref = "badRequest"),
-            @ApiResponse(responseCode = "401", ref = "unauthorized"),
-            @ApiResponse(responseCode = "404", ref = "notFound"),
-            @ApiResponse(responseCode = "500", ref = "internalServerError")
-    })
     @Operation(summary = "Register new account", description = "Creates a new user account using email and password.")
     @PostMapping("/sign-up")
     public ResponseData<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
@@ -44,12 +36,7 @@ public class AuthController {
         return new ResponseData<>(HttpStatus.CREATED.value(), "User registered successfully", response);
     }
 
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "400", ref = "badRequest"),
-            @ApiResponse(responseCode = "401", ref = "unauthorized"),
-            @ApiResponse(responseCode = "404", ref = "notFound"),
-            @ApiResponse(responseCode = "500", ref = "internalServerError")
-    })
+
     @Operation(summary= "User login", description = "Authenticate user using email and password.")
     @PostMapping("/log-in")
     public ResponseData<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
@@ -68,12 +55,7 @@ public class AuthController {
                 .build();
     }
 
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "400", ref = "badRequest"),
-            @ApiResponse(responseCode = "401", ref = "unauthorized"),
-            @ApiResponse(responseCode = "404", ref = "notFound"),
-            @ApiResponse(responseCode = "500", ref = "internalServerError")
-    })
+
     @Operation(summary = "Log out the user", description = "Terminates the user's session and invalidates the authentication token.")
     @PostMapping("/log-out")
     public ResponseData<Void> logout(@RequestBody LogoutRequest request) throws ParseException, JOSEException {

--- a/src/main/java/com/hoangtrang/taskoserver/controller/CategoryController.java
+++ b/src/main/java/com/hoangtrang/taskoserver/controller/CategoryController.java
@@ -1,0 +1,84 @@
+package com.hoangtrang.taskoserver.controller;
+
+import com.hoangtrang.taskoserver.config.security.CustomUserDetails;
+import com.hoangtrang.taskoserver.dto.request.CategoryRequest;
+import com.hoangtrang.taskoserver.dto.response.CategoryResponse;
+import com.hoangtrang.taskoserver.dto.response.ResponseData;
+import com.hoangtrang.taskoserver.model.User;
+import com.hoangtrang.taskoserver.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Category Controller")
+@RequestMapping("/api/categories")
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class CategoryController {
+
+    CategoryService categoryService;
+
+    @Operation(summary = "Create a new category")
+    @PostMapping
+    public ResponseData<CategoryResponse> createCategory(
+            @RequestBody CategoryRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+            ) {
+        User user = customUserDetails.user();
+        CategoryResponse response = categoryService.createCategory(request, user);
+        return new ResponseData<CategoryResponse>(HttpStatus.CREATED.value(),
+                "Created new category successfully", response);
+    }
+
+
+    @Operation(summary = "Get all categories")
+    @GetMapping
+    public ResponseData<List<CategoryResponse>> getCategories(@AuthenticationPrincipal CustomUserDetails user) {
+        var result = categoryService.getCategories(user.user());
+        return new ResponseData<>(HttpStatus.OK.value(), "Get categories list successfully",result);
+    }
+
+    @Operation(summary = "Get category by id")
+    @GetMapping("/{id}")
+    public ResponseData<CategoryResponse> getCategoryById(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        CategoryResponse result = categoryService.getCategoryById(id, user.user());
+        return new ResponseData<>(HttpStatus.OK.value(), "Get category successfully", result);
+    }
+
+
+    @Operation(summary = "Update category")
+    @PutMapping("/{id}")
+    public ResponseData<CategoryResponse> updateCategory(
+            @PathVariable UUID id,
+            @RequestBody CategoryRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        CategoryResponse response = categoryService.updateCategory(id, request, user.user());
+        return new ResponseData<>(HttpStatus.OK.value(), "Updated category successfully", response);
+    }
+
+
+    @Operation(summary = "Delete category")
+    @DeleteMapping("/{id}")
+    public ResponseData<Void> deleteCategory(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        categoryService.deleteCategory(id, user.user());
+        return new ResponseData<>(HttpStatus.NO_CONTENT.value(), "Delete category successfully");
+    }
+
+
+}

--- a/src/main/java/com/hoangtrang/taskoserver/dto/request/CategoryRequest.java
+++ b/src/main/java/com/hoangtrang/taskoserver/dto/request/CategoryRequest.java
@@ -1,0 +1,3 @@
+package com.hoangtrang.taskoserver.dto.request;
+
+public record CategoryRequest(String name) {}

--- a/src/main/java/com/hoangtrang/taskoserver/dto/response/CategoryResponse.java
+++ b/src/main/java/com/hoangtrang/taskoserver/dto/response/CategoryResponse.java
@@ -1,0 +1,6 @@
+package com.hoangtrang.taskoserver.dto.response;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record CategoryResponse(UUID id, String name, OffsetDateTime createdAt) {}

--- a/src/main/java/com/hoangtrang/taskoserver/exception/ErrorStatus.java
+++ b/src/main/java/com/hoangtrang/taskoserver/exception/ErrorStatus.java
@@ -16,6 +16,9 @@ public enum ErrorStatus {
     PASSWORD_INVALID(1006, "Password must be at least 8 characters", HttpStatus.BAD_REQUEST),
     USER_NOT_EXISTED(1007, "User doesn't exist", HttpStatus.NOT_FOUND),
     UNAUTHENTICATED(1100, "Unauthenticated", HttpStatus.UNAUTHORIZED),
+    CATEGORY_EXISTED(1008, "Category already existed", HttpStatus.BAD_REQUEST),
+    CATEGORY_NOT_FOUND(1009, "Category doesn't exist", HttpStatus.NOT_FOUND),
+
     UNAUTHORIZED(1101, "You do not have permission", HttpStatus.FORBIDDEN),
     ACCESS_TOKEN_EXPIRED(1102, "Access token expired", HttpStatus.UNAUTHORIZED),
     REFRESH_TOKEN_EXPIRED(1103, "Refresh token expired, please login again", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/hoangtrang/taskoserver/mapper/CategoryMapper.java
+++ b/src/main/java/com/hoangtrang/taskoserver/mapper/CategoryMapper.java
@@ -1,0 +1,12 @@
+package com.hoangtrang.taskoserver.mapper;
+
+import com.hoangtrang.taskoserver.dto.request.CategoryRequest;
+import com.hoangtrang.taskoserver.dto.response.CategoryResponse;
+import com.hoangtrang.taskoserver.model.Category;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+    Category toCategory(CategoryRequest request);
+    CategoryResponse toCategoryResponse(Category category);
+}

--- a/src/main/java/com/hoangtrang/taskoserver/model/Category.java
+++ b/src/main/java/com/hoangtrang/taskoserver/model/Category.java
@@ -1,28 +1,27 @@
 package com.hoangtrang.taskoserver.model;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
-@Setter
-@Getter
 @Entity
-@Table(name="users")
-public class User {
+@Getter
+@Setter
+@Table(name = "categories")
+public class Category {
     @Id
     @GeneratedValue(generator = "UUID")
-    @Column(name = "id", updatable = false, nullable = false, columnDefinition = "uuid")
+    @Column(name="id", nullable = false)
     private UUID id;
 
-    @Column(name="email", unique = true, nullable = false)
-    private String email;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id", nullable = false)
+    private User user;
 
-    @Column(name="password", nullable = false)
-    private String password;
-
-    @Column(name="name")
+    @Column(name="name", nullable = false, length = 100)
     private String name;
 
     @Column(name="created_at", updatable = false)
@@ -32,6 +31,4 @@ public class User {
     protected void onCreate() {
         createdAt = OffsetDateTime.now();
     }
-
-
 }

--- a/src/main/java/com/hoangtrang/taskoserver/repository/CategoryRepository.java
+++ b/src/main/java/com/hoangtrang/taskoserver/repository/CategoryRepository.java
@@ -1,0 +1,18 @@
+package com.hoangtrang.taskoserver.repository;
+
+import com.hoangtrang.taskoserver.model.Category;
+import com.hoangtrang.taskoserver.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+    List<Category> findAllByUser(User user);
+
+    Optional<Category> findByIdAndUser(UUID id, User user);
+}
+

--- a/src/main/java/com/hoangtrang/taskoserver/service/CategoryService.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/CategoryService.java
@@ -1,0 +1,21 @@
+package com.hoangtrang.taskoserver.service;
+
+import com.hoangtrang.taskoserver.dto.request.CategoryRequest;
+import com.hoangtrang.taskoserver.dto.response.CategoryResponse;
+import com.hoangtrang.taskoserver.model.User;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CategoryService {
+    CategoryResponse createCategory(CategoryRequest request, User user);
+
+    List<CategoryResponse> getCategories(User user);
+
+    CategoryResponse getCategoryById(UUID id, User user);
+
+    CategoryResponse updateCategory(UUID id, CategoryRequest request, User user);
+
+    void deleteCategory(UUID id, User user);
+
+}

--- a/src/main/java/com/hoangtrang/taskoserver/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/impl/CategoryServiceImpl.java
@@ -1,0 +1,77 @@
+package com.hoangtrang.taskoserver.service.impl;
+
+import com.hoangtrang.taskoserver.dto.request.CategoryRequest;
+import com.hoangtrang.taskoserver.dto.response.CategoryResponse;
+import com.hoangtrang.taskoserver.exception.AppException;
+import com.hoangtrang.taskoserver.exception.ErrorStatus;
+import com.hoangtrang.taskoserver.mapper.CategoryMapper;
+import com.hoangtrang.taskoserver.model.Category;
+import com.hoangtrang.taskoserver.model.User;
+import com.hoangtrang.taskoserver.repository.CategoryRepository;
+import com.hoangtrang.taskoserver.repository.UserRepository;
+import com.hoangtrang.taskoserver.service.CategoryService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class CategoryServiceImpl implements CategoryService {
+    CategoryRepository categoryRepository;
+    UserRepository userRepository;
+    CategoryMapper categoryMapper;
+
+
+    @Override
+    public CategoryResponse createCategory(CategoryRequest request, User user) {
+        User foundUser = userRepository.findByEmail(user.getEmail())
+                .orElseThrow(() -> new AppException(ErrorStatus.USER_NOT_EXISTED));
+
+        Category category = categoryMapper.toCategory(request);
+        category.setUser(foundUser);
+
+        Category savedCategory = categoryRepository.save(category);
+
+        return categoryMapper.toCategoryResponse(savedCategory);
+
+    }
+
+    @Override
+    public List<CategoryResponse> getCategories(User user) {
+        User foundUser = userRepository.findByEmail(user.getEmail())
+                .orElseThrow(() -> new AppException(ErrorStatus.USER_NOT_EXISTED));
+
+        return categoryRepository.findAllByUser(foundUser)
+                 .stream().map(categoryMapper::toCategoryResponse)
+                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public CategoryResponse getCategoryById(UUID id, User user) {
+        Category category = categoryRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new AppException(ErrorStatus.CATEGORY_NOT_FOUND));
+        return categoryMapper.toCategoryResponse(category);
+    }
+
+    @Override
+    public CategoryResponse updateCategory(UUID id, CategoryRequest request, User user) {
+        Category category = categoryRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new AppException(ErrorStatus.CATEGORY_NOT_FOUND));
+        category.setName(request.name());
+        Category updatedCategory = categoryRepository.save(category);
+        return categoryMapper.toCategoryResponse(updatedCategory);
+    }
+
+    @Override
+    public void deleteCategory(UUID id, User user) {
+        Category category = categoryRepository.findByIdAndUser(id, user)
+                .orElseThrow(() -> new AppException(ErrorStatus.CATEGORY_NOT_FOUND));
+        categoryRepository.delete(category);
+    }
+}


### PR DESCRIPTION
**Description**
This PR implements authentication-protected CRUD operations for the `Category` entity and improves how responses are displayed in Swagger UI.

**Changes**
- Secured Category CRUD
  - All category endpoints now require authentication via JWT.
  - Includes create, read (all/by ID), update, and delete functionality.
- Swagger Error UI Enhancement
  - Improved Swagger documentation and response format
  - Standardized responses for clearer display in Swagger.
  - Started using `record` for simple DTOs.
