### PR TITLE
Enhance task due date handling with time support and fix filtering logic

### DIFF
--- a/src/main/java/com/hoangtrang/taskoserver/controller/TaskController.java
+++ b/src/main/java/com/hoangtrang/taskoserver/controller/TaskController.java
@@ -50,7 +50,7 @@ public class TaskController {
 
     @Operation(
             summary = "Get tasks with filters",
-            description = "Retrieve tasks by applying only one filter at a time: inbox=true, categoryId, dueDate, or status (overdue, upcoming, completed)."
+            description = "Retrieve tasks by applying only one filter at a time: inbox=true, categoryId, dueDate, or status (overdue, today, upcoming, completed)."
     )
     @GetMapping
     public ResponseData<List<TaskResponse>> getFilterTasks(

--- a/src/main/java/com/hoangtrang/taskoserver/dto/task/TaskRequest.java
+++ b/src/main/java/com/hoangtrang/taskoserver/dto/task/TaskRequest.java
@@ -1,12 +1,14 @@
 package com.hoangtrang.taskoserver.dto.task;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hoangtrang.taskoserver.model.enums.DueType;
 import com.hoangtrang.taskoserver.model.enums.PriorityLevel;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Data
@@ -20,8 +22,12 @@ public class TaskRequest {
 
         String description;
 
+        DueType dueType;
+
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate dueDate;
+
+        OffsetDateTime dueDateTime;
 
         PriorityLevel priority;
 

--- a/src/main/java/com/hoangtrang/taskoserver/dto/task/TaskResponse.java
+++ b/src/main/java/com/hoangtrang/taskoserver/dto/task/TaskResponse.java
@@ -1,6 +1,7 @@
 package com.hoangtrang.taskoserver.dto.task;
 
 import com.hoangtrang.taskoserver.dto.category.CategoryResponse;
+import com.hoangtrang.taskoserver.model.enums.DueType;
 import com.hoangtrang.taskoserver.model.enums.PriorityLevel;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
@@ -18,7 +19,9 @@ public class TaskResponse {
     UUID id;
     String title;
     String description;
+    DueType dueType;
     LocalDate dueDate;
+    OffsetDateTime dueDateTime;
     PriorityLevel priority;
     Boolean isCompleted;
     OffsetDateTime completedAt;

--- a/src/main/java/com/hoangtrang/taskoserver/dto/task/UpdateTaskRequest.java
+++ b/src/main/java/com/hoangtrang/taskoserver/dto/task/UpdateTaskRequest.java
@@ -1,6 +1,7 @@
 package com.hoangtrang.taskoserver.dto.task;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hoangtrang.taskoserver.model.enums.DueType;
 import com.hoangtrang.taskoserver.model.enums.PriorityLevel;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
@@ -20,8 +21,12 @@ public class UpdateTaskRequest {
 
     String description;
 
+    DueType dueType;
+
     @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate dueDate;
+
+    OffsetDateTime dueDateTime;
 
     PriorityLevel priority;
 

--- a/src/main/java/com/hoangtrang/taskoserver/exception/ErrorStatus.java
+++ b/src/main/java/com/hoangtrang/taskoserver/exception/ErrorStatus.java
@@ -23,6 +23,9 @@ public enum ErrorStatus {
     TOKEN_NOT_FOUND(1013, "Reset token doesn't exist", HttpStatus.NOT_FOUND),
     TOKEN_EXPIRED(1014, "Reset token expired", HttpStatus.BAD_REQUEST),
     TOKEN_ALREADY_USED(1015, "Reset token already used", HttpStatus.BAD_REQUEST),
+    INVALID_DUE_DATE(1016, "DueDate must not be null when dueType is DATE", HttpStatus.BAD_REQUEST),
+    INVALID_DUE_DATE_TIME(1017, "DueDateTime must not be null when dueType is DATETIME", HttpStatus.BAD_REQUEST),
+
 
     UNAUTHORIZED(1101, "You do not have permission", HttpStatus.FORBIDDEN),
     UNAUTHENTICATED(1100, "Unauthenticated", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/hoangtrang/taskoserver/mapper/TaskMapper.java
+++ b/src/main/java/com/hoangtrang/taskoserver/mapper/TaskMapper.java
@@ -50,7 +50,7 @@ public interface TaskMapper {
     @Mapping(target = "updatedAt", ignore = true)
     @Mapping(target = "isCompleted", ignore = true)
     @Mapping(target = "completedAt", ignore = true)
-    @Mapping(target = "dueAtUtc", ignore = true) // set in @AfterMapping
+    @Mapping(target = "dueAt", ignore = true) // set in @AfterMapping
     @Mapping(target = "dueType", source = "request.dueType", defaultExpression = "java(DueType.NONE)")
     Task toTask(TaskRequest request, UUID userId);
 
@@ -61,7 +61,8 @@ public interface TaskMapper {
     @Mapping(target = "updatedAt", ignore = true)
     @Mapping(target = "isCompleted", ignore = true)
     @Mapping(target = "completedAt", ignore = true)
-    @Mapping(target = "dueAtUtc", ignore = true) // set in @AfterMapping
+    @Mapping(target = "dueAt", ignore = true) // set in @AfterMapping
+    @Mapping(target = "dueType", ignore = true)
     void updateTaskFromDto(TaskRequest request, @MappingTarget Task task);
 
     // after map
@@ -77,7 +78,11 @@ public interface TaskMapper {
 
     @AfterMapping
     default void setDueTimeAfterUpdate(TaskRequest request, @MappingTarget Task task) {
-        if (request.getDueType() != null) {
+        if (
+                request.getDueType() != null ||
+                        request.getDueDate() != null ||
+                        request.getDueDateTime() != null
+        ) {
             TaskDueTimeHelper.setDueTime(
                     task,
                     request.getDueType(),

--- a/src/main/java/com/hoangtrang/taskoserver/mapper/TaskMapper.java
+++ b/src/main/java/com/hoangtrang/taskoserver/mapper/TaskMapper.java
@@ -4,37 +4,90 @@ import com.hoangtrang.taskoserver.dto.task.TaskRequest;
 import com.hoangtrang.taskoserver.dto.task.TaskResponse;
 import com.hoangtrang.taskoserver.model.Category;
 import com.hoangtrang.taskoserver.model.Task;
+import com.hoangtrang.taskoserver.model.enums.DueType;
 import com.hoangtrang.taskoserver.model.enums.PriorityLevel;
+import com.hoangtrang.taskoserver.service.TaskDueTimeHelper;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 import java.util.UUID;
 
-@Mapper(componentModel = "spring", uses = CategoryMapper.class, imports = {PriorityLevel.class})
+@Mapper(
+        componentModel = "spring",
+        uses = CategoryMapper.class,
+        imports = {PriorityLevel.class, DueType.class, TaskDueTimeHelper.class}
+)
 public interface TaskMapper {
 
+    //response
     @Mapping(target = "id", source = "task.id")
     @Mapping(target = "createdAt", source = "task.createdAt")
     @Mapping(target = "category", source = "category")
     @Mapping(target = "inboxTask", expression = "java(task.isInboxTask())")
     @Mapping(target = "todayTask", expression = "java(task.isTodayTask())")
     @Mapping(target = "overdue", expression = "java(task.isOverdue())")
+    @Mapping(target = "dueType", source = "task.dueType")
+    @Mapping(target = "dueDate", expression = "java(TaskDueTimeHelper.extractDueDate(task))")
+    @Mapping(target = "dueDateTime", expression = "java(TaskDueTimeHelper.extractDueDateTime(task))")
     TaskResponse toTaskResponse(Task task, Category category);
 
     @Mapping(target = "inboxTask", expression = "java(task.isInboxTask())")
     @Mapping(target = "todayTask", expression = "java(task.isTodayTask())")
     @Mapping(target = "overdue", expression = "java(task.isOverdue())")
+    @Mapping(target = "dueType", source = "task.dueType")
+    @Mapping(target = "dueDate", expression = "java(TaskDueTimeHelper.extractDueDate(task))")
+    @Mapping(target = "dueDateTime", expression = "java(TaskDueTimeHelper.extractDueDateTime(task))")
     TaskResponse toTaskResponse(Task task);
 
+    //create
+    @Mapping(target = "id", ignore = true)
     @Mapping(target = "userId", source = "userId")
     @Mapping(target = "categoryId", source = "request.categoryId")
     @Mapping(target = "priority", source = "request.priority", defaultExpression = "java(getDefaultPriority())")
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "isCompleted", ignore = true)
+    @Mapping(target = "completedAt", ignore = true)
+    @Mapping(target = "dueAtUtc", ignore = true) // set in @AfterMapping
+    @Mapping(target = "dueType", source = "request.dueType", defaultExpression = "java(DueType.NONE)")
     Task toTask(TaskRequest request, UUID userId);
+
+    //update
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "isCompleted", ignore = true)
+    @Mapping(target = "completedAt", ignore = true)
+    @Mapping(target = "dueAtUtc", ignore = true) // set in @AfterMapping
+    void updateTaskFromDto(TaskRequest request, @MappingTarget Task task);
+
+    // after map
+    @AfterMapping
+    default void setDueTimeAfterCreate(TaskRequest request, @MappingTarget Task task) {
+        TaskDueTimeHelper.setDueTime(
+                task,
+                request.getDueType(),
+                request.getDueDate(),
+                request.getDueDateTime()
+        );
+    }
+
+    @AfterMapping
+    default void setDueTimeAfterUpdate(TaskRequest request, @MappingTarget Task task) {
+        if (request.getDueType() != null) {
+            TaskDueTimeHelper.setDueTime(
+                    task,
+                    request.getDueType(),
+                    request.getDueDate(),
+                    request.getDueDateTime()
+            );
+        }
+    }
 
     default PriorityLevel getDefaultPriority() {
         return PriorityLevel.LOW;
     }
-
-    void updateTaskFromDto(TaskRequest dto, @MappingTarget Task task);
 }

--- a/src/main/java/com/hoangtrang/taskoserver/mapper/TaskMapper.java
+++ b/src/main/java/com/hoangtrang/taskoserver/mapper/TaskMapper.java
@@ -26,17 +26,17 @@ public interface TaskMapper {
     @Mapping(target = "createdAt", source = "task.createdAt")
     @Mapping(target = "category", source = "category")
     @Mapping(target = "inboxTask", expression = "java(task.isInboxTask())")
-    @Mapping(target = "todayTask", expression = "java(task.isTodayTask())")
-    @Mapping(target = "overdue", expression = "java(task.isOverdue())")
+    @Mapping(target = "todayTask", ignore = true)
+    @Mapping(target = "overdue", ignore = true)
     @Mapping(target = "dueType", source = "task.dueType")
     @Mapping(target = "dueDate", expression = "java(TaskDueTimeHelper.extractDueDate(task))")
     @Mapping(target = "dueDateTime", expression = "java(TaskDueTimeHelper.extractDueDateTime(task))")
     TaskResponse toTaskResponse(Task task, Category category);
 
     @Mapping(target = "inboxTask", expression = "java(task.isInboxTask())")
-    @Mapping(target = "todayTask", expression = "java(task.isTodayTask())")
-    @Mapping(target = "overdue", expression = "java(task.isOverdue())")
     @Mapping(target = "dueType", source = "task.dueType")
+    @Mapping(target = "todayTask", ignore = true)
+    @Mapping(target = "overdue", ignore = true)
     @Mapping(target = "dueDate", expression = "java(TaskDueTimeHelper.extractDueDate(task))")
     @Mapping(target = "dueDateTime", expression = "java(TaskDueTimeHelper.extractDueDateTime(task))")
     TaskResponse toTaskResponse(Task task);

--- a/src/main/java/com/hoangtrang/taskoserver/model/Task.java
+++ b/src/main/java/com/hoangtrang/taskoserver/model/Task.java
@@ -27,8 +27,8 @@ public class Task {
     private String title;
     private String description;
 
-    @Column(name="due_at_utc")
-    private OffsetDateTime dueAtUtc;
+    @Column(name="due_at")
+    private OffsetDateTime dueAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name="due_type")
@@ -73,20 +73,20 @@ public class Task {
 
     public boolean isTodayTask() {
         if (!hasDueDate()) return false;
-        LocalDate taskDate = dueAtUtc.toLocalDate();
+        LocalDate taskDate = dueAt.toLocalDate();
         return taskDate.equals(LocalDate.now());
     }
 
     public boolean isOverdue() {
         if (isCompleted || !hasDueDate()) return false;
-        return dueAtUtc.isBefore(OffsetDateTime.now());
+        return dueAt.isBefore(OffsetDateTime.now());
     }
 
     public LocalDate getDueDate() {
-        return hasDueDate() ? dueAtUtc.toLocalDate() : null;
+        return hasDueDate() ? dueAt.toLocalDate() : null;
     }
 
     public OffsetDateTime getDueDateTime() {
-        return (dueType == DueType.DATE_TIME) ? dueAtUtc : null;
+        return (dueType == DueType.DATE_TIME) ? dueAt : null;
     }
 }

--- a/src/main/java/com/hoangtrang/taskoserver/model/Task.java
+++ b/src/main/java/com/hoangtrang/taskoserver/model/Task.java
@@ -71,22 +71,4 @@ public class Task {
         return dueType != null && dueType != DueType.NONE;
     }
 
-    public boolean isTodayTask() {
-        if (!hasDueDate()) return false;
-        LocalDate taskDate = dueAt.toLocalDate();
-        return taskDate.equals(LocalDate.now());
-    }
-
-    public boolean isOverdue() {
-        if (isCompleted || !hasDueDate()) return false;
-        return dueAt.isBefore(OffsetDateTime.now());
-    }
-
-    public LocalDate getDueDate() {
-        return hasDueDate() ? dueAt.toLocalDate() : null;
-    }
-
-    public OffsetDateTime getDueDateTime() {
-        return (dueType == DueType.DATE_TIME) ? dueAt : null;
-    }
 }

--- a/src/main/java/com/hoangtrang/taskoserver/model/enums/DueType.java
+++ b/src/main/java/com/hoangtrang/taskoserver/model/enums/DueType.java
@@ -1,0 +1,7 @@
+package com.hoangtrang.taskoserver.model.enums;
+
+public enum DueType {
+    NONE,
+    DATE,
+    DATE_TIME
+}

--- a/src/main/java/com/hoangtrang/taskoserver/repository/TaskRepository.java
+++ b/src/main/java/com/hoangtrang/taskoserver/repository/TaskRepository.java
@@ -21,6 +21,16 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             "ORDER BY t.createdAt")
     List<Task> findInboxTasks(@Param("userId") UUID userId);
 
+    // Tasks today
+    @Query("SELECT t FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
+            "AND t.dueType != 'NONE' " +
+            "AND t.dueAt < :startOfTomorrow " +
+            "ORDER BY t.dueAt")
+    List<Task> findTodayTasks(
+            @Param("userId") UUID userId,
+            @Param("startOfTomorrow") OffsetDateTime startOfTomorrow
+    );
+
     // Tasks by date
     @Query("SELECT t FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
@@ -29,7 +39,8 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
     List<Task> findTasksByDueDate(
             @Param("userId") UUID userId,
             @Param("startOfDay") OffsetDateTime startOfDay,
-            @Param("endOfDay") OffsetDateTime endOfDay);
+            @Param("endOfDay") OffsetDateTime endOfDay
+    );
 
     // Tasks by date list
     @Query("SELECT t FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
@@ -41,16 +52,16 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
     // Overdue
     @Query("SELECT t FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND t.dueAt < :now " +
+            "AND t.dueAt < :startOfToday " +
             "ORDER BY t.dueAt")
-    List<Task> findOverdueTasks(@Param("userId") UUID userId, @Param("now") OffsetDateTime now);
+    List<Task> findOverdueTasks(@Param("userId") UUID userId, @Param("startOfToday") OffsetDateTime startOfToday);
 
     // Upcoming
     @Query("SELECT t FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND t.dueAt > :now " +
+            "AND t.dueAt > :startOfTomorrow " +
             "ORDER BY t.dueAt")
-    List<Task> findUpComingTasks(@Param("userId") UUID userId, @Param("now") OffsetDateTime now);
+    List<Task> findUpComingTasks(@Param("userId") UUID userId, @Param("startOfTomorrow") OffsetDateTime startOfTomorrow);
 
     // By category
     @Query("SELECT t FROM Task t WHERE t.userId = :userId " +
@@ -70,18 +81,18 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
 
     @Query("SELECT COUNT(t) FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND CAST(t.dueAt AS date) = :today")
-    long countTodayTasks(@Param("userId") UUID userId, @Param("today") LocalDate today);
+            "AND t.dueAt < :startOfTomorrow")
+    long countTodayTasks(@Param("userId") UUID userId, @Param("startOfTomorrow") OffsetDateTime startOfTomorrow);
 
     @Query("SELECT COUNT(t) FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND t.dueAt < :now")
-    long countOverdueTasks(@Param("userId") UUID userId, @Param("now") OffsetDateTime now);
+            "AND t.dueAt < :startOfToday")
+    long countOverdueTasks(@Param("userId") UUID userId, @Param("startOfToday") OffsetDateTime startOfToday);
 
     @Query("SELECT COUNT(t) FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND t.dueAt > :now")
-    long countUpComingTasks(@Param("userId") UUID userId, @Param("now") OffsetDateTime now);
+            "AND t.dueAt > :startOfTomorrow")
+    long countUpComingTasks(@Param("userId") UUID userId, @Param("startOfTomorrow") OffsetDateTime startOfTomorrow);
 
     Optional<Task> findByIdAndUserId(UUID id, UUID userId);
 

--- a/src/main/java/com/hoangtrang/taskoserver/repository/TaskRepository.java
+++ b/src/main/java/com/hoangtrang/taskoserver/repository/TaskRepository.java
@@ -24,8 +24,8 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
     // Tasks by date
     @Query("SELECT t FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND t.dueAtUtc >= :startOfDay AND t.dueAtUtc <= :endOfDay " +
-            "ORDER BY t.dueAtUtc")
+            "AND t.dueAt >= :startOfDay AND t.dueAt <= :endOfDay " +
+            "ORDER BY t.dueAt")
     List<Task> findTasksByDueDate(
             @Param("userId") UUID userId,
             @Param("startOfDay") OffsetDateTime startOfDay,
@@ -34,28 +34,28 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
     // Tasks by date list
     @Query("SELECT t FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND CAST(t.dueAtUtc AS date) IN :dates " +
-            "ORDER BY t.dueAtUtc")
+            "AND CAST(t.dueAt AS date) IN :dates " +
+            "ORDER BY t.dueAt")
     List<Task> findTasksByDueDateList(@Param("userId") UUID userId, @Param("dates") List<LocalDate> dates);
 
     // Overdue
     @Query("SELECT t FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND t.dueAtUtc < :now " +
-            "ORDER BY t.dueAtUtc")
+            "AND t.dueAt < :now " +
+            "ORDER BY t.dueAt")
     List<Task> findOverdueTasks(@Param("userId") UUID userId, @Param("now") OffsetDateTime now);
 
     // Upcoming
     @Query("SELECT t FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND t.dueAtUtc > :now " +
-            "ORDER BY t.dueAtUtc")
+            "AND t.dueAt > :now " +
+            "ORDER BY t.dueAt")
     List<Task> findUpComingTasks(@Param("userId") UUID userId, @Param("now") OffsetDateTime now);
 
     // By category
     @Query("SELECT t FROM Task t WHERE t.userId = :userId " +
             "AND t.categoryId = :categoryId AND t.isCompleted = false " +
-            "ORDER BY t.dueAtUtc NULLS LAST, t.createdAt")
+            "ORDER BY t.dueAt NULLS LAST, t.createdAt")
     List<Task> findTasksByCategory(@Param("userId") UUID userId, @Param("categoryId") UUID categoryId);
 
     // Completed
@@ -70,17 +70,17 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
 
     @Query("SELECT COUNT(t) FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND CAST(t.dueAtUtc AS date) = :today")
+            "AND CAST(t.dueAt AS date) = :today")
     long countTodayTasks(@Param("userId") UUID userId, @Param("today") LocalDate today);
 
     @Query("SELECT COUNT(t) FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND t.dueAtUtc < :now")
+            "AND t.dueAt < :now")
     long countOverdueTasks(@Param("userId") UUID userId, @Param("now") OffsetDateTime now);
 
     @Query("SELECT COUNT(t) FROM Task t WHERE t.userId = :userId AND t.isCompleted = false " +
             "AND t.dueType != 'NONE' " +
-            "AND t.dueAtUtc > :now")
+            "AND t.dueAt > :now")
     long countUpComingTasks(@Param("userId") UUID userId, @Param("now") OffsetDateTime now);
 
     Optional<Task> findByIdAndUserId(UUID id, UUID userId);

--- a/src/main/java/com/hoangtrang/taskoserver/scheduler/PasswordResetCleanupJob.java
+++ b/src/main/java/com/hoangtrang/taskoserver/scheduler/PasswordResetCleanupJob.java
@@ -1,6 +1,7 @@
 package com.hoangtrang.taskoserver.scheduler;
 
 import com.hoangtrang.taskoserver.repository.PasswordResetTokenRepository;
+import jakarta.transaction.Transactional;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -16,6 +17,7 @@ import java.time.temporal.ChronoUnit;
 public class PasswordResetCleanupJob {
     PasswordResetTokenRepository tokenRepository;
 
+    @Transactional
     @Scheduled(cron = "0 0 * * * *") // run every hour
     public void cleanupExpiredTokens() {
         Instant now = Instant.now();

--- a/src/main/java/com/hoangtrang/taskoserver/service/TaskDueTimeHelper.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/TaskDueTimeHelper.java
@@ -14,7 +14,7 @@ public class TaskDueTimeHelper {
 
     public static void setNoDueDate(Task task) {
         task.setDueType(DueType.NONE);
-        task.setDueAtUtc(null);
+        task.setDueAt(null);
     }
 
     public static void setDueDate(Task task, LocalDate date) {
@@ -24,22 +24,20 @@ public class TaskDueTimeHelper {
 
         task.setDueType(DueType.DATE);
 
-        OffsetDateTime endOfDayUtc = date
+        OffsetDateTime endOfDay = date
                 .atTime(23, 59, 59)
                 .atZone(AppTime.APP_ZONE)     // VN time
-                .withZoneSameInstant(ZoneOffset.UTC)
                 .toOffsetDateTime();
 
-        task.setDueAtUtc(endOfDayUtc);
+        task.setDueAt(endOfDay);
     }
 
     public static void setDueDateTime(Task task, OffsetDateTime dateTime) {
-        System.out.println("dateTime = " + dateTime);
         if (dateTime == null) {
             throw new AppException(ErrorStatus.INVALID_DUE_DATE_TIME);
         }
         task.setDueType(DueType.DATE_TIME);
-        task.setDueAtUtc(dateTime.withOffsetSameInstant(ZoneOffset.UTC));
+        task.setDueAt(dateTime);
     }
 
 
@@ -58,32 +56,27 @@ public class TaskDueTimeHelper {
         if (task.getDueType() == null || task.getDueType() == DueType.NONE) {
             return null;
         }
-        if (task.getDueAtUtc() == null) {
+        if (task.getDueAt() == null) {
             return null;
         }
 
-        return task.getDueAtUtc()
-                .atZoneSameInstant(AppTime.APP_ZONE)
-                .toLocalDate();
+        return task.getDueAt().toLocalDate();
     }
 
 
     public static OffsetDateTime extractDueDateTime(Task task) {
-        if (task.getDueType() == DueType.DATE_TIME && task.getDueAtUtc() != null) {
-            return task.getDueAtUtc();
+        if (task.getDueType() == DueType.DATE_TIME && task.getDueAt() != null) {
+            return task.getDueAt();
         }
         return null;
     }
 
-    public static OffsetDateTime startOfDayUtc(LocalDate date) {
-        return date.atStartOfDay(AppTime.APP_ZONE)          // start of day in user’s timezone
-                .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
-                .toOffsetDateTime();
+    public static OffsetDateTime startOfDay(LocalDate date) {
+        return date.atStartOfDay(AppTime.APP_ZONE).toOffsetDateTime();          // start of day in user’s timezone
     }
 
-    public static OffsetDateTime endOfDayUtc(LocalDate date) {
+    public static OffsetDateTime endOfDay(LocalDate date) {
         return date.plusDays(1).atStartOfDay(AppTime.APP_ZONE)  // start of next day
-                .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
                 .toOffsetDateTime();
     }
 

--- a/src/main/java/com/hoangtrang/taskoserver/service/TaskDueTimeHelper.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/TaskDueTimeHelper.java
@@ -1,0 +1,90 @@
+package com.hoangtrang.taskoserver.service;
+
+import com.hoangtrang.taskoserver.exception.AppException;
+import com.hoangtrang.taskoserver.exception.ErrorStatus;
+import com.hoangtrang.taskoserver.model.Task;
+import com.hoangtrang.taskoserver.model.enums.DueType;
+import com.hoangtrang.taskoserver.util.AppTime;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+public class TaskDueTimeHelper {
+
+    public static void setNoDueDate(Task task) {
+        task.setDueType(DueType.NONE);
+        task.setDueAtUtc(null);
+    }
+
+    public static void setDueDate(Task task, LocalDate date) {
+        if (date == null) {
+            throw new AppException(ErrorStatus.INVALID_DUE_DATE);
+        }
+
+        task.setDueType(DueType.DATE);
+
+        OffsetDateTime endOfDayUtc = date
+                .atTime(23, 59, 59)
+                .atZone(AppTime.APP_ZONE)     // VN time
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toOffsetDateTime();
+
+        task.setDueAtUtc(endOfDayUtc);
+    }
+
+    public static void setDueDateTime(Task task, OffsetDateTime dateTime) {
+        System.out.println("dateTime = " + dateTime);
+        if (dateTime == null) {
+            throw new AppException(ErrorStatus.INVALID_DUE_DATE_TIME);
+        }
+        task.setDueType(DueType.DATE_TIME);
+        task.setDueAtUtc(dateTime.withOffsetSameInstant(ZoneOffset.UTC));
+    }
+
+
+    public static void setDueTime(Task task, DueType dueType, LocalDate dueDate, OffsetDateTime dueDateTime) {
+        if (dueType == null || dueType == DueType.NONE) {
+            setNoDueDate(task);
+        } else if (dueType == DueType.DATE) {
+            setDueDate(task, dueDate);
+        } else if (dueType == DueType.DATE_TIME) {
+            setDueDateTime(task, dueDateTime);
+        }
+    }
+
+
+    public static LocalDate extractDueDate(Task task) {
+        if (task.getDueType() == null || task.getDueType() == DueType.NONE) {
+            return null;
+        }
+        if (task.getDueAtUtc() == null) {
+            return null;
+        }
+
+        return task.getDueAtUtc()
+                .atZoneSameInstant(AppTime.APP_ZONE)
+                .toLocalDate();
+    }
+
+
+    public static OffsetDateTime extractDueDateTime(Task task) {
+        if (task.getDueType() == DueType.DATE_TIME && task.getDueAtUtc() != null) {
+            return task.getDueAtUtc();
+        }
+        return null;
+    }
+
+    public static OffsetDateTime startOfDayUtc(LocalDate date) {
+        return date.atStartOfDay(AppTime.APP_ZONE)          // start of day in user’s timezone
+                .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
+                .toOffsetDateTime();
+    }
+
+    public static OffsetDateTime endOfDayUtc(LocalDate date) {
+        return date.plusDays(1).atStartOfDay(AppTime.APP_ZONE)  // start of next day
+                .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
+                .toOffsetDateTime();
+    }
+
+}

--- a/src/main/java/com/hoangtrang/taskoserver/service/TaskDueTimeHelper.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/TaskDueTimeHelper.java
@@ -23,7 +23,7 @@ public class TaskDueTimeHelper {
         }
 
         task.setDueType(DueType.DATE);
-        task.setDueAt(endOfDay(date));
+        task.setDueAt(startOfDay(date));
     }
 
     public static void setDueDateTime(Task task, OffsetDateTime dateTime) {
@@ -54,11 +54,7 @@ public class TaskDueTimeHelper {
             return null;
         }
 
-        if(task.getDueType() == DueType.DATE) {
-            return task.getDueAt().minusNanos(1).toLocalDate();
-        }
-
-        return task.getDueAt().toLocalDate();
+        return task.getDueAt().atZoneSameInstant(AppTime.APP_ZONE).toLocalDate();
     }
 
 

--- a/src/main/java/com/hoangtrang/taskoserver/service/TaskDueTimeHelper.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/TaskDueTimeHelper.java
@@ -23,13 +23,7 @@ public class TaskDueTimeHelper {
         }
 
         task.setDueType(DueType.DATE);
-
-        OffsetDateTime endOfDay = date
-                .atTime(23, 59, 59)
-                .atZone(AppTime.APP_ZONE)     // VN time
-                .toOffsetDateTime();
-
-        task.setDueAt(endOfDay);
+        task.setDueAt(endOfDay(date));
     }
 
     public static void setDueDateTime(Task task, OffsetDateTime dateTime) {
@@ -58,6 +52,10 @@ public class TaskDueTimeHelper {
         }
         if (task.getDueAt() == null) {
             return null;
+        }
+
+        if(task.getDueType() == DueType.DATE) {
+            return task.getDueAt().minusNanos(1).toLocalDate();
         }
 
         return task.getDueAt().toLocalDate();

--- a/src/main/java/com/hoangtrang/taskoserver/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/impl/TaskServiceImpl.java
@@ -10,8 +10,10 @@ import com.hoangtrang.taskoserver.mapper.CategoryMapper;
 import com.hoangtrang.taskoserver.mapper.TaskMapper;
 import com.hoangtrang.taskoserver.model.Category;
 import com.hoangtrang.taskoserver.model.Task;
+import com.hoangtrang.taskoserver.model.enums.DueType;
 import com.hoangtrang.taskoserver.repository.CategoryRepository;
 import com.hoangtrang.taskoserver.repository.TaskRepository;
+import com.hoangtrang.taskoserver.service.TaskDueTimeHelper;
 import com.hoangtrang.taskoserver.service.TaskService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -39,8 +41,11 @@ public class TaskServiceImpl implements TaskService {
     @Override
     @Transactional
     public TaskResponse createTask(TaskRequest request, UUID userId) {
+        validateDueTimeRequest(request);
+
         Task task = taskMapper.toTask(request, userId);
 
+        TaskDueTimeHelper.setDueTime(task, request.getDueType(), request.getDueDate(), request.getDueDateTime());
         Category category = null;
         if(request.getCategoryId() != null) {
             category = categoryRepository.findByIdAndUserId(request.getCategoryId(), userId)
@@ -76,23 +81,26 @@ public class TaskServiceImpl implements TaskService {
         }).toList();
 
         return result.stream()
+                .filter(task -> task.getDueDate() != null)
                 .collect(Collectors.groupingBy(TaskResponse::getDueDate));
     }
 
-
     @Override
-    public List<TaskResponse> filterTasks(UUID userId, String status,LocalDate dueDate, UUID categoryId, Boolean inbox) {
+    public List<TaskResponse> filterTasks(UUID userId, String status, LocalDate dueDate,
+                                          UUID categoryId, Boolean inbox) {
         List<Task> tasks;
-        LocalDate today = LocalDate.now();
+        OffsetDateTime nowUtc = OffsetDateTime.now(ZoneOffset.UTC);
 
         if(Boolean.TRUE.equals(inbox)) {
             tasks = taskRepository.findInboxTasks(userId);
         } else if(dueDate != null) {
-            tasks = taskRepository.findTasksByDueDate(userId,dueDate);
+            OffsetDateTime startUtc = TaskDueTimeHelper.startOfDayUtc(dueDate);
+            OffsetDateTime endUtc = TaskDueTimeHelper.endOfDayUtc(dueDate);
+            tasks = taskRepository.findTasksByDueDate(userId, startUtc, endUtc);
         } else if ("overdue".equalsIgnoreCase(status)) {
-            tasks = taskRepository.findOverdueTasks(userId, today);
+            tasks = taskRepository.findOverdueTasks(userId, nowUtc);
         } else if ("upcoming".equalsIgnoreCase(status)) {
-            tasks = taskRepository.findUpComingTasks(userId, today);
+            tasks = taskRepository.findUpComingTasks(userId, nowUtc);
         } else if ("completed".equalsIgnoreCase(status)) {
             tasks = taskRepository.findCompletedTasks(userId);
         } else if (categoryId != null) {
@@ -101,6 +109,120 @@ public class TaskServiceImpl implements TaskService {
             tasks = taskRepository.findAllByUserId(userId);
         }
 
+        return mapTasksToResponses(tasks);
+    }
+
+    @Override
+    public CountTaskResponse countTasks(UUID userId) {
+        LocalDate today = LocalDate.now();
+        OffsetDateTime now = OffsetDateTime.now();
+
+        long countInbox = taskRepository.countInboxTasks(userId);
+        long countToday = taskRepository.countTodayTasks(userId, today);
+        long countOverdue = taskRepository.countOverdueTasks(userId, now);
+        long countUpcoming = taskRepository.countUpComingTasks(userId, now);
+
+        return CountTaskResponse.builder()
+                .inbox(countInbox)
+                .today(countToday)
+                .overdue(countOverdue)
+                .upcoming(countUpcoming)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public TaskResponse updateTask(UUID taskId, UUID userId, TaskRequest updateTask) {
+        // Validation với dueType
+        validateDueTimeRequest(updateTask);
+
+        Task task = loadTaskByUserId(taskId, userId);
+        taskMapper.updateTaskFromDto(updateTask, task);
+        // dueAtUtc và dueType đã được update trong mapper's @AfterMapping
+
+        Task savedTask = taskRepository.save(task);
+
+        Category category = null;
+        if (updateTask.getCategoryId() != null) {
+            category = categoryRepository.findByIdAndUserId(updateTask.getCategoryId(), userId)
+                    .orElseThrow(() -> new AppException(ErrorStatus.CATEGORY_NOT_FOUND));
+        }
+
+        return taskMapper.toTaskResponse(savedTask, category);
+    }
+
+    @Override
+    @Transactional
+    public TaskResponse patchTask(UUID taskId, UUID userId, UpdateTaskRequest updateTask) {
+        Task task = loadTaskByUserId(taskId, userId);
+
+        if(updateTask.getTitle() != null) {
+            task.setTitle(updateTask.getTitle());
+        }
+
+        if(updateTask.getDescription() != null) {
+            task.setDescription(updateTask.getDescription());
+        }
+
+        if(updateTask.getDueType() != null) {
+            validateDueTimeRequest(updateTask);
+
+            // Set due time based on type
+            TaskDueTimeHelper.setDueTime(
+                    task,
+                    updateTask.getDueType(),
+                    updateTask.getDueDate(),
+                    updateTask.getDueDateTime()
+            );
+        }
+
+        if(updateTask.getPriority() != null) {
+            task.setPriority(updateTask.getPriority());
+        }
+
+        // Logic completed task
+        if(updateTask.getIsCompleted() != null) {
+            task.setIsCompleted(updateTask.getIsCompleted());
+            if(updateTask.getIsCompleted()) {
+                task.setCompletedAt(OffsetDateTime.now(ZoneOffset.UTC));
+            } else {
+                task.setCompletedAt(null);
+            }
+        }
+
+        // Category logic
+        Category category = null;
+        if (updateTask.getCategoryId() != null) {
+            category = categoryRepository.findByIdAndUserId(updateTask.getCategoryId(), userId)
+                    .orElseThrow(() -> new AppException(ErrorStatus.CATEGORY_NOT_FOUND));
+            task.setCategoryId(updateTask.getCategoryId());
+        } else if (updateTask.getCategoryId() == null && updateTask.getTitle() != null) {
+            // Nếu explicitly set null (distinguish từ không gửi field)
+            task.setCategoryId(null);
+        }
+
+        Task savedTask = taskRepository.save(task);
+        return taskMapper.toTaskResponse(savedTask, category);
+    }
+
+    @Override
+    @Transactional
+    public void deleteTask(UUID taskId, UUID userId) {
+        Task task = loadTaskByUserId(taskId, userId);
+        taskRepository.delete(task);
+    }
+
+    // ========== PRIVATE HELPER METHODS ==========
+
+    private Task loadTaskByUserId(UUID taskId, UUID userId) {
+        return taskRepository.findByIdAndUserId(taskId, userId)
+                .orElseThrow(() -> new AppException(ErrorStatus.TASK_NOT_FOUND));
+    }
+
+    /**
+     * Map list of tasks to responses with categories
+     */
+    private List<TaskResponse> mapTasksToResponses(List<Task> tasks) {
         Set<UUID> categoryIds = tasks.stream()
                 .map(Task::getCategoryId)
                 .filter(Objects::nonNull)
@@ -122,78 +244,52 @@ public class TaskServiceImpl implements TaskService {
         }).toList();
     }
 
-    @Override
-    public CountTaskResponse countTasks(UUID userId) {
-        LocalDate today = LocalDate.now();
-        long countInbox = taskRepository.countInboxTasks(userId);
-        long countToday = taskRepository.countTodayTasks(userId, today);
-        long countOverdue = taskRepository.countOverdueTasks(userId, today);
-        long countUpcoming = taskRepository.countUpComingTasks(userId, today);
-
-        return CountTaskResponse.builder()
-                .inbox(countInbox)
-                .today(countToday)
-                .overdue(countOverdue)
-                .upcoming(countUpcoming)
-                .build();
-    }
-
-    private Task loadTaskByUserId(UUID taskId, UUID userId) {
-        return taskRepository.findByIdAndUserId(taskId, userId)
-                .orElseThrow(() -> new AppException(ErrorStatus.TASK_NOT_FOUND));
-    }
-    @Override
-    @Transactional
-    public TaskResponse updateTask(UUID taskId, UUID userId, TaskRequest updateTask) {
-        Task task = loadTaskByUserId(taskId, userId);
-        taskMapper.updateTaskFromDto(updateTask, task);
-        Task savedTask = taskRepository.save(task);
-        
-        Category category = null;
-        if (updateTask.getCategoryId() != null) {
-            category = categoryRepository.findByIdAndUserId(updateTask.getCategoryId(), userId)
-                    .orElseThrow(() -> new AppException(ErrorStatus.CATEGORY_NOT_FOUND));
+    /**
+     * Validate due time request
+     */
+    private void validateDueTimeRequest(TaskRequest request) {
+        if (request.getDueType() == null) {
+            return;
         }
-        
-        return taskMapper.toTaskResponse(savedTask, category);
-    }
 
-    @Override
-    @Transactional
-    public TaskResponse patchTask(UUID taskId, UUID userId, UpdateTaskRequest updateTask) {
-        Task task = loadTaskByUserId(taskId, userId);
-        if(updateTask.getTitle() != null) task.setTitle(updateTask.getTitle());
-        if(updateTask.getDescription() != null) task.setDescription(updateTask.getDescription());
-        if(updateTask.getDueDate() != null) task.setDueDate(updateTask.getDueDate());
-        if(updateTask.getPriority() != null) task.setPriority(updateTask.getPriority());
+        switch (request.getDueType()) {
+            case DATE -> {
+                if (request.getDueDate() == null || request.getDueDateTime() != null) {
+                    throw new AppException(ErrorStatus.INVALID_DUE_DATE);
+                }
+            }
 
-        // logic with completed task
-        if(updateTask.getIsCompleted() != null) {
-            task.setIsCompleted(updateTask.getIsCompleted());
-            if(updateTask.getIsCompleted()) {
-                task.setCompletedAt(OffsetDateTime.now(ZoneOffset.UTC));
-            } else {
-                task.setCompletedAt(null);
+            case DATE_TIME -> {
+                if (request.getDueDateTime() == null || request.getDueDate() != null) {
+                    throw new AppException(ErrorStatus.INVALID_DUE_DATE_TIME);
+                }
+            }
+
+            case NONE -> {
+                if (request.getDueDate() != null || request.getDueDateTime() != null) {
+                    throw new AppException(ErrorStatus.INVALID_DUE_DATE_TIME);
+                }
             }
         }
-
-        Category category = null;
-
-        if (updateTask.getCategoryId() != null) {
-         category = categoryRepository.findByIdAndUserId(updateTask.getCategoryId(), userId)
-                .orElseThrow(() -> new AppException(ErrorStatus.CATEGORY_NOT_FOUND));
-            task.setCategoryId(updateTask.getCategoryId());
-        } else {
-            task.setCategoryId(null);
-        }
-        Task savedTask = taskRepository.save(task);
-        return taskMapper.toTaskResponse(savedTask, category);
     }
 
-    @Override
-    @Transactional
-    public void deleteTask(UUID taskId, UUID userId) {
-        Task task = loadTaskByUserId(taskId, userId);
-        taskRepository.delete(task);
+
+    /**
+     * Validate due time for patch request
+     */
+    private void validateDueTimeRequest(UpdateTaskRequest request) {
+        if (request.getDueType() == null) {
+            return;
+        }
+
+        if (request.getDueType() == DueType.DATE) {
+            if (request.getDueDate() == null) {
+                throw new AppException(ErrorStatus.INVALID_DUE_DATE);
+            }
+        } else if (request.getDueType() == DueType.DATE_TIME) {
+            if (request.getDueDateTime() == null) {
+                throw new AppException(ErrorStatus.INVALID_DUE_DATE_TIME);
+            }
+        }
     }
 }

--- a/src/main/java/com/hoangtrang/taskoserver/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/impl/TaskServiceImpl.java
@@ -94,9 +94,9 @@ public class TaskServiceImpl implements TaskService {
         if(Boolean.TRUE.equals(inbox)) {
             tasks = taskRepository.findInboxTasks(userId);
         } else if(dueDate != null) {
-            OffsetDateTime startUtc = TaskDueTimeHelper.startOfDayUtc(dueDate);
-            OffsetDateTime endUtc = TaskDueTimeHelper.endOfDayUtc(dueDate);
-            tasks = taskRepository.findTasksByDueDate(userId, startUtc, endUtc);
+            OffsetDateTime start = TaskDueTimeHelper.startOfDay(dueDate);
+            OffsetDateTime end = TaskDueTimeHelper.endOfDay(dueDate);
+            tasks = taskRepository.findTasksByDueDate(userId, start, end);
         } else if ("overdue".equalsIgnoreCase(status)) {
             tasks = taskRepository.findOverdueTasks(userId, nowUtc);
         } else if ("upcoming".equalsIgnoreCase(status)) {

--- a/src/main/java/com/hoangtrang/taskoserver/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/impl/TaskServiceImpl.java
@@ -124,7 +124,7 @@ public class TaskServiceImpl implements TaskService {
             tasks = taskRepository.findAllByUserId(userId);
         }
 
-        return mapTasksToResponses(tasks, status);
+        return mapTasksToResponses(tasks);
     }
 
 
@@ -211,8 +211,7 @@ public class TaskServiceImpl implements TaskService {
             category = categoryRepository.findByIdAndUserId(updateTask.getCategoryId(), userId)
                     .orElseThrow(() -> new AppException(ErrorStatus.CATEGORY_NOT_FOUND));
             task.setCategoryId(updateTask.getCategoryId());
-        } else if (updateTask.getCategoryId() == null && updateTask.getTitle() != null) {
-            // Nếu explicitly set null (distinguish từ không gửi field)
+        } else {
             task.setCategoryId(null);
         }
 
@@ -237,7 +236,7 @@ public class TaskServiceImpl implements TaskService {
     /**
      * Map list of tasks to responses with categories
      */
-    private List<TaskResponse> mapTasksToResponses(List<Task> tasks, String status) {
+    private List<TaskResponse> mapTasksToResponses(List<Task> tasks) {
         Set<UUID> categoryIds = tasks.stream()
                 .map(Task::getCategoryId)
                 .filter(Objects::nonNull)

--- a/src/main/java/com/hoangtrang/taskoserver/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/hoangtrang/taskoserver/service/impl/TaskServiceImpl.java
@@ -133,12 +133,10 @@ public class TaskServiceImpl implements TaskService {
     @Override
     @Transactional
     public TaskResponse updateTask(UUID taskId, UUID userId, TaskRequest updateTask) {
-        // Validation với dueType
         validateDueTimeRequest(updateTask);
 
         Task task = loadTaskByUserId(taskId, userId);
         taskMapper.updateTaskFromDto(updateTask, task);
-        // dueAtUtc và dueType đã được update trong mapper's @AfterMapping
 
         Task savedTask = taskRepository.save(task);
 

--- a/src/main/java/com/hoangtrang/taskoserver/util/AppTime.java
+++ b/src/main/java/com/hoangtrang/taskoserver/util/AppTime.java
@@ -8,5 +8,5 @@ public final class AppTime {
     private AppTime() {}
 
     public static final ZoneId APP_ZONE = ZoneId.of("Asia/Ho_Chi_Minh");
-    public static final ZoneOffset UTC = ZoneOffset.UTC;
+    public static final ZoneOffset APP_OFFSET = ZoneOffset.ofHours(7);
 }

--- a/src/main/java/com/hoangtrang/taskoserver/util/AppTime.java
+++ b/src/main/java/com/hoangtrang/taskoserver/util/AppTime.java
@@ -1,0 +1,12 @@
+package com.hoangtrang.taskoserver.util;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+public final class AppTime {
+
+    private AppTime() {}
+
+    public static final ZoneId APP_ZONE = ZoneId.of("Asia/Ho_Chi_Minh");
+    public static final ZoneOffset UTC = ZoneOffset.UTC;
+}


### PR DESCRIPTION
## Description
This PR adds **due time support** for tasks and fixes several related business logics to ensure tasks are categorized and filtered correctly.

## Changes

### 1. Support datetime for `dueTime` and correct task status
- Users can now set a specific time for a task’s due date.  
- Previously, only date-only or no due date was supported.  
- All due times now use a single timezone: **UTC+7**.  
- Applies to both **adding new tasks and updating existing tasks**.  

### 2. Update filtering logic
- **Overdue:** `dueDateTime < startOfToday()`  
- **Today:** `startOfToday() <= dueDateTime < startOfTomorrow()`  
- **Upcoming:** `dueDateTime >= startOfTomorrow()`  
- Added a dedicated filter for `status = today`
- Filtering by dueDate now applies only when browsing the calendar.

### 3. Fix task category handling
- Tasks moved between categories are now correctly transferred to the inbox.